### PR TITLE
fix: end value has mixed support, using flex-end instead

### DIFF
--- a/packages/component/container/element-plus/element-plus.scss
+++ b/packages/component/container/element-plus/element-plus.scss
@@ -79,7 +79,7 @@ $containerPrefix: #{$defaultPrefix}__#{$componentPrefix};
     width: 100%;
     display: flex;
     align-items: center;
-    justify-content: end;
+    justify-content: flex-end;
 
     svg {
       width: 16px;


### PR DESCRIPTION
![image](https://github.com/flingyp/vitepress-demo-preview/assets/30397306/f4fe93c4-9558-4db6-be6e-4334477f1b4d)
